### PR TITLE
Fix Blender 5.2 compatibility: Geometry Nodes modifier material input assignment

### DIFF
--- a/operators/view_checker_map.py
+++ b/operators/view_checker_map.py
@@ -65,7 +65,7 @@ class UV_OT_mio3_checker_map(Mio3UVGlobalOperator):
             modifier = obj.modifiers.new(name=NAME_MOD_CHECKER_MAP, type="NODES")
             modifier.show_expanded = False
             modifier.node_group = geometry_node
-            modifier["Socket_2"] = mat
+            modifier.properties.inputs.Socket_2.value = mat
             obj.select_set(True)
 
         if mode != "OBJECT":


### PR DESCRIPTION
Blender 5.2 changed the GeometryNodesModifier API to NodesModifier, and the old dictionary-style property assignment `(modifier["Socket_2"] = mat)` no longer works for ID data-blocks like Materials.

So "Set Checker Map" would fail with:
`TypeError: bpy_struct[key] = val: id properties not supported for this type`

In Blender 5.2, modifier inputs are accessed via `modifier.properties.inputs.<identifier>.value` using dot notation (RNA attributes), not bracket notation (custom properties). The `.value` property on these input attributes properly accepts Material references.

**Change (line 68)**
_Before (broken in Blender 5.2)_
`modifier["Socket_2"] = mat`

_After (Blender 5.2 compatible)_
`modifier.properties.inputs.Socket_2.value = mat`

Verified on Blender 5.2 — the material now correctly appears in the modifier's "Material" input socket without requiring manual assignment.